### PR TITLE
Fix a parser lock for malformed freeform array items

### DIFF
--- a/test.js
+++ b/test.js
@@ -42,8 +42,14 @@ this: isn't a field`,
 
   freeform: [
     { type: "text", value: "this is a test block" },
-    { type: "key", value: "value" }
+    { type: "key", value: "value" },
+    { type: "quote", value: {
+      text: "Correctly parses."
+    }}
   ],
+  quote: {
+    error: "This should exit the array."
+  },
   strings: [
     "test",
     "a",

--- a/test_document.txt
+++ b/test_document.txt
@@ -37,6 +37,15 @@ not: in options
 this is a test block
 
 key: value
+
+{.quote}
+text: Correctly parses.
+{}
+
+{quote}
+error: This should exit the array.
+{}
+
 []
 
 


### PR DESCRIPTION
If a freeform array contained an item without a leading `.` indicating that it's a sub-object of the array, Betty would lock in an infinite loop. This isn't _technically_ related to the freeform array: it has to do with the new object instruction moving the current scope of the assembler back out of the array (correctly), and then the `closeArray()` function not checking for the output object root when it encounters the (now unnecessary) `[]` tag and tries to backtrack past the nearest array scope. I think simple arrays are immune to this because they bail out for any non-list syntax, so we hadn't hit the repro conditions before.

Weirdly enough, there was no test case in the original NYT set to catch this. I've added a case to the Betty test document and our own automated tests to make sure that it works correctly.